### PR TITLE
Unmount if already mounted

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -23,6 +23,7 @@ nsenter -t 1 -m -u -i -n sh -c " \
     apk update && \
     apk add inotify-tools && \
     mkdir -p $MOUNT && \
+    (umount $MOUNT || /bin/true) && \
     mount -t cifs $SERVER $MOUNT -o $OPTIONS && \
     inotifywait -m $MOUNT \
     "


### PR DESCRIPTION
When running the container a second time, it will fail because shared directory is already mounted on host. This change allow the container to unmount before mounting the share again.